### PR TITLE
iteration optimisations

### DIFF
--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -241,7 +241,7 @@ withFrozenMessage k msg = bracket (message_freeze msg) message_thaw k
 
 -- | Set tags for the message.  Atomic.
 --
-messageSetTags :: MonadIO m => Foldable t => t Tag -> Message 0 RW -> m ()
+messageSetTags :: (MonadIO m, Foldable t) => t Tag -> Message 0 RW -> m ()
 messageSetTags l = liftIO . withFrozenMessage (\msg ->
   message_remove_all_tags msg *> traverse_ (message_add_tag msg) l)
 

--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -547,18 +547,13 @@ constructF mkF dcon constructor destructor =
 -- | Turn a C iterator into a list
 --
 ptrToList
-  :: (p -> (Ptr p -> IO [b]) -> IO [b])
-  -- ^ Pointer unwrapper function (e.g. `withMessages`)
-  -> (Ptr p -> IO (CInt))
-  -- ^ Predicate on iterator
-  -> (Ptr p -> IO a)
-  -- ^ Iterater getter function
-  -> (Ptr p -> IO ())
-  -- ^ Function to advance iterator
-  -> (a -> IO b)
-  -- ^ Item mapper
-  -> p
-  -- ^ Pointer
+  :: (obj -> (ptr -> IO [b]) -> IO [b])
+  -- ^ Object unwrapper function (e.g. `withMessages`)
+  -> (ptr -> IO CInt) -- ^ Iterator predicate function
+  -> (ptr -> IO a)    -- ^ Iterator get function
+  -> (ptr -> IO ())   -- ^ Iterator next function
+  -> (a -> IO b)      -- ^ Item mapper
+  -> obj              -- ^ Object
   -> IO [b]
 ptrToList withFObj test get next f fObj = withFObj fObj ptrToList'
   where


### PR DESCRIPTION
This PR contains a series of commits that optimise iteration.  In particular

- avoid use of `ForeignPtr` for iterating `notmuch_tags_t`.  This improves memory usage
  when reading tags on lots of messages.

- lazily read message and thread iterators (`notmuch_(thread|message)s_t`).  This defers each
  read of the iterator until its value is demanded.  This reduces maximum memory usage when
  processing long lists (earlier parts can be GC'd) and avoids computation/allocation for parts
  of the list that are never demanded.