### PR TITLE
Make `Tag` an opaque type and add some test programs

### DIFF
--- a/notmuch.cabal
+++ b/notmuch.cabal
@@ -78,3 +78,15 @@ executable hs-notmuch-tag-message
     , bytestring
     , mtl
     , notmuch
+
+executable hs-notmuch-tag-count
+  default-language:    Haskell2010
+  hs-source-dirs: tools
+  ghc-options: -Wall
+  main-is: TagCount.hs
+  build-depends:
+    base         >= 4.9
+    , bytestring
+    , mtl
+    , containers
+    , notmuch

--- a/notmuch.cabal
+++ b/notmuch.cabal
@@ -34,6 +34,8 @@ library
 
   other-modules:
     Notmuch.Binding
+    Notmuch.Binding.Constants
+    Notmuch.Tag
     Notmuch.Talloc
 
   build-depends:

--- a/notmuch.cabal
+++ b/notmuch.cabal
@@ -90,3 +90,14 @@ executable hs-notmuch-tag-count
     , mtl
     , containers
     , notmuch
+
+executable hs-notmuch-tag-set
+  default-language:    Haskell2010
+  hs-source-dirs: tools
+  ghc-options: -Wall
+  main-is: TagSet.hs
+  build-depends:
+    base         >= 4.9
+    , bytestring
+    , mtl
+    , notmuch

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -135,9 +135,6 @@ instance HasTags (Database a) where
 instance HasTags (Thread a) where
   tags = liftIO . thread_get_tags
 
-instance HasTags Messages where
-  tags = liftIO . messages_collect_tags
-
 instance HasTags (Message n a) where
   tags = liftIO . message_get_tags
 

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -92,6 +92,9 @@ module Notmuch
   , messageHeader
   , messageFilename
   , messageSetTags
+  , messageAddTag
+  , messageRemoveTag
+  , withFrozenMessage
 
   , HasTags(..)
   , HasMessages(..)
@@ -242,6 +245,22 @@ withFrozenMessage k msg = bracket (message_freeze msg) message_thaw k
 messageSetTags :: (MonadIO m, Foldable t) => t Tag -> Message 0 RW -> m ()
 messageSetTags l = liftIO . withFrozenMessage (\msg ->
   message_remove_all_tags msg *> traverse_ (message_add_tag msg) l)
+
+-- | Add the tag to a message.  If adding/removing multiple tags,
+-- use 'messageSetTags' to set the whole tag list atomically, or use
+-- 'withFrozenMessage' to avoid inconsistent states when
+-- adding/removing tags.
+--
+messageAddTag :: (MonadIO m) => Tag -> Message 0 RW -> m ()
+messageAddTag tag msg = liftIO $ message_add_tag msg tag
+
+-- | Remove the tag from a message.  If adding/removing multiple
+-- tags, use 'messageSetTags' to set the whole tag list atomically,
+-- or use 'withFrozenMessage' to avoid inconsistent states when
+-- adding/removing tags.
+--
+messageRemoveTag :: (MonadIO m) => Tag -> Message 0 RW -> m ()
+messageRemoveTag tag msg = liftIO $ message_remove_tag msg tag
 
 -- | Returns only messages in a thread which are not replies to other messages in the thread.
 threadToplevelMessages

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -114,6 +114,7 @@ import qualified Data.Text.Encoding as T
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
+import Notmuch.Tag
 import Notmuch.Binding
 import Notmuch.Search
 import Notmuch.Util

--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -446,16 +446,29 @@ message_remove_all_tags msg = withMessage msg $ \ptr ->
 
 -- According to the header file, possible errors are:
 --
--- * NOTMUCH_STATUS_NULL_POINTER (excluded by @B.useAsCString@)
--- * NOTMUCH_STATUS_TAG_TOO_LONG (excluded by @Tag@ smart constructor)
+-- * NOTMUCH_STATUS_NULL_POINTER (excluded by @Tag@ type)
+-- * NOTMUCH_STATUS_TAG_TOO_LONG (excluded by @Tag@ type)
 -- * NOTMUCH_STATUS_READ_ONLY_DATABASE (excluded by @Message RW@)
 --
 -- Therefore assume everything worked!
 --
 message_add_tag :: Message n RW -> Tag -> IO ()
 message_add_tag msg tag = withMessage msg $ \ptr ->
-  tagUseAsCString tag $ \s' ->
-    void $ {#call message_add_tag #} ptr s'
+  tagUseAsCString tag $ \s ->
+    void $ {#call message_add_tag #} ptr s
+
+-- According to the header file, possible errors are:
+--
+-- * NOTMUCH_STATUS_NULL_POINTER (excluded by @Tag@ type)
+-- * NOTMUCH_STATUS_TAG_TOO_LONG (excluded by @Tag@ type)
+-- * NOTMUCH_STATUS_READ_ONLY_DATABASE (excluded by @Message RW@)
+--
+-- Therefore assume everything worked!
+--
+message_remove_tag :: Message n RW -> Tag -> IO ()
+message_remove_tag msg tag = withMessage msg $ \ptr ->
+  tagUseAsCString tag $ \s ->
+    void $ {#call message_remove_tag #} ptr s
 
 -- According to the header file, possible errors are:
 --
@@ -479,7 +492,6 @@ message_thaw :: (CmpNat n 0 ~ 'GT) => Message n RW -> IO (Message (n - 1) RW)
 message_thaw msg = withMessage msg $ \ptr ->
   coerce msg <$ {#call message_thaw #} ptr
 
--- message_remove_tag
 -- message_maildir_flags_to_tags
 -- message_tags_to_maildir_flags
 

--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -261,9 +261,9 @@ query_get_sort ptr = withQuery ptr $
   fmap (toEnum . fromIntegral) . {#call query_get_sort #}
 
 query_add_tag_exclude :: Query a -> Tag -> IO ()
-query_add_tag_exclude ptr (Tag s) = void $
+query_add_tag_exclude ptr tag = void $
   withQuery ptr $ \ptr' ->
-    B.useAsCString s $ \s' ->
+    tagUseAsCString tag $ \s' ->
       {#call query_add_tag_exclude #} ptr' s'
 
 query_search_threads
@@ -453,8 +453,8 @@ message_remove_all_tags msg = withMessage msg $ \ptr ->
 -- Therefore assume everything worked!
 --
 message_add_tag :: Message n RW -> Tag -> IO ()
-message_add_tag msg (Tag s) = withMessage msg $ \ptr ->
-  B.useAsCString s $ \s' ->
+message_add_tag msg tag = withMessage msg $ \ptr ->
+  tagUseAsCString tag $ \s' ->
     void $ {#call message_add_tag #} ptr s'
 
 -- According to the header file, possible errors are:
@@ -580,7 +580,7 @@ tagsToList = ptrToList
   {#call tags_valid #}
   {#call tags_get #}
   {#call tags_move_to_next #}
-  (fmap Tag . B.packCString)
+  tagFromCString
 
 threadsToList :: Threads -> IO [Thread a]
 threadsToList = lazyPtrToList

--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -384,13 +384,6 @@ thread_get_tags :: Thread a -> IO [Tag]
 thread_get_tags ptr = withThread ptr $ \ptr' ->
   {#call thread_get_tags #} ptr' >>= tagsToList
 
--- Tags are always copied from the libnotmuch-managed memory,
--- and all the copying takes place under 'withMessages', so
--- we don't need to detach the pointer or use a ForeignPtr.
-messages_collect_tags :: Messages -> IO [Tag]
-messages_collect_tags ptr = withMessages ptr $ \ptr' ->
-  {#call messages_collect_tags #} ptr' >>= tagsToList
-
 message_get_message_id :: Message n a -> IO MessageId
 message_get_message_id ptr =
   withMessage ptr ({#call message_get_message_id #} >=> B.packCString)

--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -34,6 +34,7 @@ import Data.Functor.Identity (Identity(..))
 import Data.Proxy
 import GHC.TypeLits
 
+import Notmuch.Tag
 import Notmuch.Util
 
 #include <notmuch.h>
@@ -57,15 +58,6 @@ import Notmuch.Talloc
 --
 type MessageId = B.ByteString
 type ThreadId = B.ByteString
-
-newtype Tag = Tag { getTag :: B.ByteString }
-
--- | @Just@ a tag, or @Nothing@ if the string is too long
-
-mkTag :: B.ByteString -> Maybe Tag
-mkTag s
-  | B.length s > {#const NOTMUCH_TAG_MAX #} = Nothing
-  | otherwise = Just (Tag s)
 
 --
 -- BINDING API

--- a/src/Notmuch/Binding/Constants.chs
+++ b/src/Notmuch/Binding/Constants.chs
@@ -1,0 +1,24 @@
+-- Copyright (C) 2017  Fraser Tweedale
+--
+-- hs-notmuch is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+module Notmuch.Binding.Constants
+  (
+    tagMaxLen
+  ) where
+
+#include <notmuch.h>
+
+tagMaxLen :: Int
+tagMaxLen = {#const NOTMUCH_TAG_MAX #}

--- a/src/Notmuch/Search.hs
+++ b/src/Notmuch/Search.hs
@@ -4,7 +4,8 @@ import Data.Semigroup ((<>))
 
 import qualified Data.ByteString.Char8 as C
 
-import Notmuch.Binding (Tag, MessageId, ThreadId, getTag)
+import Notmuch.Tag (Tag, getTag)
+import Notmuch.Binding (MessageId, ThreadId)
 
 data SearchTerm
   = FreeForm String

--- a/src/Notmuch/Tag.hs
+++ b/src/Notmuch/Tag.hs
@@ -1,0 +1,32 @@
+-- Copyright (C) 2017  Fraser Tweedale
+--
+-- hs-notmuch is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+module Notmuch.Tag where
+
+import qualified Data.ByteString as B
+
+import Notmuch.Binding.Constants (tagMaxLen)
+
+newtype Tag = Tag { getTag :: B.ByteString }
+
+-- | @Just@ a tag, or @Nothing@ if the string is too long
+mkTag :: B.ByteString -> Maybe Tag
+mkTag s =
+  let
+    w = B.length s
+  in
+    if w < 1 || w > tagMaxLen
+      then Nothing
+      else Just (Tag s)

--- a/src/Notmuch/Tag.hs
+++ b/src/Notmuch/Tag.hs
@@ -28,6 +28,10 @@ import Foreign.C (CString)
 import Notmuch.Binding.Constants (tagMaxLen)
 
 newtype Tag = Tag { getTag :: B.ByteString }
+  deriving (Eq, Ord)
+
+instance Show Tag where
+  show (Tag s) = show s
 
 -- | @Just@ a tag, or @Nothing@ if the string is too long
 mkTag :: B.ByteString -> Maybe Tag

--- a/src/Notmuch/Tag.hs
+++ b/src/Notmuch/Tag.hs
@@ -13,9 +13,17 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-module Notmuch.Tag where
+module Notmuch.Tag
+  (
+    Tag
+  , getTag
+  , mkTag
+  , tagUseAsCString
+  , tagFromCString
+  ) where
 
 import qualified Data.ByteString as B
+import Foreign.C (CString)
 
 import Notmuch.Binding.Constants (tagMaxLen)
 
@@ -30,3 +38,9 @@ mkTag s =
     if w < 1 || w > tagMaxLen
       then Nothing
       else Just (Tag s)
+
+tagUseAsCString :: Tag -> (CString -> IO a) -> IO a
+tagUseAsCString = B.useAsCString . getTag
+
+tagFromCString :: CString -> IO Tag
+tagFromCString = fmap Tag . B.packCString

--- a/tools/TagCount.hs
+++ b/tools/TagCount.hs
@@ -1,0 +1,51 @@
+-- This file is part of hs-notmuch - Haskell Notmuch binding
+-- Copyright (C) 2017  Fraser Tweedale
+--
+-- hs-notmuch is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-
+
+Search a notmuch database and print the filenames of each email found.
+
+-}
+
+{-# LANGUAGE LambdaCase #-}
+
+import Control.Monad ((>=>), join)
+import Control.Monad.Except (runExceptT)
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.Map.Strict as M
+import System.Environment (getArgs)
+import System.Exit (die)
+
+import Notmuch
+import Notmuch.Search
+
+
+main :: IO ()
+main = getArgs >>= \case
+  [dbDir, search] -> go dbDir search
+  _ -> putStrLn "usage: hs-notmuch-tag-count DB-DIR SEARCH-TERM"
+
+go :: String -> String -> IO ()
+go dbDir searchTerm = runExceptT (
+    databaseOpenReadOnly dbDir
+    >>= (flip query (Bare searchTerm)
+          >=> messages  -- [Message]
+          >=> traverse tags -- [[Tag]]
+          >=> liftIO . print . accumTag)
+  ) >>= either (die . (show :: Status -> String)) pure
+
+accumTag :: [[Tag]] -> M.Map Tag Int
+accumTag = foldr (\k -> M.insertWith (+) k 1) M.empty . join

--- a/tools/TagSet.hs
+++ b/tools/TagSet.hs
@@ -1,0 +1,50 @@
+-- This file is part of hs-notmuch - Haskell Notmuch binding
+-- Copyright (C) 2017  Fraser Tweedale
+--
+-- hs-notmuch is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-
+
+Search a notmuch database and print the filenames of each email found.
+
+-}
+
+{-# LANGUAGE LambdaCase #-}
+
+import Control.Monad.Except (runExceptT)
+import qualified Data.ByteString.Char8 as C
+import Data.Foldable (traverse_)
+import Data.Maybe (fromJust)
+import System.Environment (getArgs)
+import System.Exit (die)
+
+import Notmuch
+import Notmuch.Search
+
+
+main :: IO ()
+main = getArgs >>= \case
+  [dbDir, search, '+':tag@(_:_)] -> go dbDir search messageAddTag tag
+  [dbDir, search, '-':tag@(_:_)] -> go dbDir search messageRemoveTag tag
+  _ -> putStrLn "usage: hs-notmuch-tag-set DB-DIR SEARCH-TERM +TAG|-TAG"
+  where
+    go dbDir searchTerm f tag =
+      let
+        tag' = fromJust $ mkTag $ C.pack tag
+      in
+        runExceptT (do
+          db <- databaseOpen dbDir
+          query db (Bare searchTerm) >>= messages >>= traverse_ (f tag')
+          databaseDestroy db
+        ) >>= either (die . (show :: Status -> String)) pure


### PR DESCRIPTION
To facilitiate the changing of the internal representation of `Tag`,
make it an opaque type.

Also add the `hs-notmuch-tag-count` and `hs-notmuch-tag-set` test
programs which are used for profiling the library.