### PR TITLE
libnotmuchVersion :: Version

### DIFF
--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -104,6 +104,9 @@ module Notmuch
   -- * Errors
   , Status(..)
   , AsNotmuchError(..)
+
+  -- * Library information
+  , libnotmuchVersion
   ) where
 
 import Control.Exception (bracket)
@@ -119,6 +122,7 @@ import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
 import Notmuch.Tag
 import Notmuch.Binding
+import Notmuch.Binding.Constants (libnotmuchVersion)
 import Notmuch.Search
 import Notmuch.Util
 

--- a/src/Notmuch/Binding/Constants.chs
+++ b/src/Notmuch/Binding/Constants.chs
@@ -15,10 +15,21 @@
 
 module Notmuch.Binding.Constants
   (
-    tagMaxLen
+    libnotmuchVersion
+  , tagMaxLen
   ) where
+
+import Data.Version (Version, makeVersion)
 
 #include <notmuch.h>
 
 tagMaxLen :: Int
 tagMaxLen = {#const NOTMUCH_TAG_MAX #}
+
+-- | The version of /libnotmuch/ that /hs-notmuch/ was built against.
+libnotmuchVersion :: Version
+libnotmuchVersion = makeVersion
+  [ {#const LIBNOTMUCH_MAJOR_VERSION #}
+  , {#const LIBNOTMUCH_MINOR_VERSION #}
+  , {#const LIBNOTMUCH_MICRO_VERSION #}
+  ]


### PR DESCRIPTION
Let the library user find out the version of libnotmuch that
hs-notmuch was compiled against.

Fixes: https://github.com/purebred-mua/hs-notmuch/issues/24