### PR TITLE
use 'unsafe' for all c calls

### DIFF
--- a/src/Notmuch/Talloc.chs
+++ b/src/Notmuch/Talloc.chs
@@ -23,4 +23,4 @@ import Foreign (Ptr, castPtr, nullPtr)
 
 detachPtr :: Ptr a -> IO (Ptr a)
 detachPtr ptr =
-  castPtr <$> {#call _talloc_steal_loc #} nullPtr (castPtr ptr) nullPtr
+  castPtr <$> {#call unsafe _talloc_steal_loc #} nullPtr (castPtr ptr) nullPtr


### PR DESCRIPTION
None of the routines we invoke can call back into the Haskell
runtime, so it is safe to use 'unsafe'.  This avoids some book
keeping, giving a big performance increase:

```
  total time  =        3.73 secs   (3728 ticks @ 1000 us, 1 processor)
  total alloc = 260,249,536 bytes  (excludes profiling overheads)
```

compared to previously:

```
  total time  =        6.53 secs   (6530 ticks @ 1000 us, 1 processor)
  total alloc = 260,249,536 bytes  (excludes profiling overheads)
```