### PR TITLE
remove bad optimisation suggestion

### DIFF
--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -419,14 +419,6 @@ message_get_date = flip withMessage {#call message_get_date #}
 -- returns EMPTY STRING on missing header,
 -- NOTHING on error (I know, confusing)
 --
--- possible optimisation: detachPtr the returned string and
--- B.unsafePackCStringFinalizer to turn it into a ByteString
--- with talloc_free finaliser.  This will be O(n) because
--- must use strlen(3) to learn string length, and avoids
--- malloc.  Measure carefully to see if this would be worth it,
--- because it couples to both notmuch internals and unstable
--- parts of bytestring API (Data.ByteString.Unsafe).
---
 message_get_header :: Message n a -> B.ByteString -> IO (Maybe B.ByteString)
 message_get_header ptr s =
   B.useAsCString s $ \s' ->


### PR DESCRIPTION
I have now measured the proposed optimisation of stealing a string
pointer with talloc_steal and finalising it with talloc_free,
instead of allocating and copying a new ByteString.

The good news is that the suggested optimisation works.

The bad news is that it isn't really an optimisation unless the
strings are quite a bit longer than the overhead of a ForeignPtr.
In our use case (tags, header values, filenames) this is not the
case.  I have profiled the approach with hs-notmuch-tags-count and
found:

- total and peak allocation substantially higher
- runtime a little lower

Overall it seems not to be worth it.