### PR TITLE
implement index/remove file capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist
+dist-newstyle/
+.ghc.environment.*
 .cabal-sandbox
 cabal.sandbox.config
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,52 +40,37 @@ before_cache:
 # we test notmuch-0.26.2 but not 0.26.1 or 0.26).
 #
 # OLDEST GHC:     8.0
-# OLDEST NOTMUCH: 0.24
+# OLDEST NOTMUCH: 0.26[.2]
 #
 matrix:
   include:
-    - compiler: "ghc-8.6.3"
-      env: NOTMUCHVER=0.24.2
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.3"
-      env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.3"
+    - compiler: "ghc-8.6.5"
+      env: NOTMUCHVER=0.26.2
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
+      env: NOTMUCHVER=0.27
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
+      env: NOTMUCHVER=0.28.4
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
       env: NOTMUCHVER=git
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
 
-    - compiler: "ghc-8.4.4"
-      env: NOTMUCHVER=0.24.2
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.4"
-      env: NOTMUCHVER=0.25.3
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
       env: NOTMUCHVER=0.26.2
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
-      env: NOTMUCHVER=0.27
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.4"
-      env: NOTMUCHVER=0.28
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.4"
-      env: NOTMUCHVER=git
+      env: NOTMUCHVER=0.28.4
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
 
     - compiler: "ghc-8.2.2"
-      env: NOTMUCHVER=0.24.2
+      env: NOTMUCHVER=0.26.2
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
-      env: NOTMUCHVER=0.28
+      env: NOTMUCHVER=0.28.4
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
 
-    - compiler: "ghc-8.0.2"
-      env: NOTMUCHVER=0.24.2
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.0.2"
-      env: NOTMUCHVER=0.25.3
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
       env: NOTMUCHVER=0.26.2
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
@@ -93,14 +78,14 @@ matrix:
       env: NOTMUCHVER=0.27
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
-      env: NOTMUCHVER=0.28
+      env: NOTMUCHVER=0.28.4
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
       env: NOTMUCHVER=git
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
 
     - compiler: "ghc-head"
-      env: NOTMUCHVER=0.24.2 GHCHEAD=true
+      env: NOTMUCHVER=0.26.2 GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head,alex,happy,g++,libxapian-dev,libgmime-2.6-dev,libtalloc-dev,zlib1g-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-head"
       env: NOTMUCHVER=0.28 GHCHEAD=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,11 @@ before_cache:
 # OLDEST GHC:     8.0
 # OLDEST NOTMUCH: 0.26[.2]
 #
+# NOTE about notmuch >= 0.29.  libgmime >= 3.0 is required.
+# It is available in Ubuntu bionic (18.04 LTS) but not earlier
+# supported versions.  Travis does not yet support bionic, so
+# 0.29 must remain in allowed_failures.
+#
 matrix:
   include:
     - compiler: "ghc-8.6.5"

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,6 @@ somewhat typesafe way to search your email.
 Requirements:
 
 - GHC 8.0 or higher
-- notmuch v0.24 or higher
+- notmuch v0.26 or higher
 
 Contributions are welcome.

--- a/notmuch.cabal
+++ b/notmuch.cabal
@@ -46,6 +46,7 @@ library
     base >= 4.9 && <5
     , bytestring >= 0.10 && < 0.11
     , deepseq >= 1.4
+    , filepath >= 1.0
     , mtl >= 2 && < 3
     , profunctors >= 5 && < 6
     , tagged >= 0.8 && < 1

--- a/notmuch.cabal
+++ b/notmuch.cabal
@@ -18,7 +18,7 @@ category:            FFI
 build-type:          Simple
 cabal-version:       >=1.10
 tested-with:
-  GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.3
+  GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5
 
 homepage:            https://github.com/purebred-mua/hs-notmuch
 bug-reports:         https://github.com/purebred-mua/hs-notmuch/issues

--- a/notmuch.cabal
+++ b/notmuch.cabal
@@ -114,3 +114,15 @@ executable hs-notmuch-tag-set
     , bytestring
     , mtl
     , notmuch
+
+executable hs-notmuch-index-file
+  if !flag(demos)
+    buildable: False
+  default-language:    Haskell2010
+  hs-source-dirs: tools
+  ghc-options: -Wall
+  main-is: IndexFile.hs
+  build-depends:
+    base         >= 4.9
+    , mtl
+    , notmuch

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 {-|
@@ -284,12 +285,11 @@ messageFilename = liftIO . message_get_filename
 
 -- | Freeze the message, run the given computation
 -- and return the result.  The message is always thawed at the end.
--- (Don't thaw the message as part of the computation!)
 --
 -- Have to start with @Message 0 RW@ due to GHC type system limitation
 -- (type-level Nat is not inductive).
 --
-withFrozenMessage :: (Message 1 RW -> IO a) -> Message 0 RW -> IO a
+withFrozenMessage :: (forall n. Message n RW -> IO a) -> Message 0 RW -> IO a
 withFrozenMessage k msg = bracket (message_freeze msg) message_thaw k
 
 -- | Set tags for the message.  Atomic.

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -121,8 +121,10 @@ module Notmuch
   , messageRemoveTag
   , withFrozenMessage
   -- ** Files
-  , indexFile
   , messageFilename
+  , indexFile
+  , removeFile
+  , RemoveResult(..)
 
   -- * Tags
   , HasTags(..)

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -110,15 +110,19 @@ module Notmuch
   , findMessage
   , HasMessages(..)
   , Message
+  -- ** Headers
   , MessageId
   , messageId
   , messageDate
   , messageHeader
-  , messageFilename
+  -- ** Tags
   , messageSetTags
   , messageAddTag
   , messageRemoveTag
   , withFrozenMessage
+  -- ** Files
+  , indexFile
+  , messageFilename
 
   -- * Tags
   , HasTags(..)

--- a/src/Notmuch.hs
+++ b/src/Notmuch.hs
@@ -70,6 +70,7 @@ module Notmuch
   -- * Opening a database
     databaseOpen
   , databaseOpenReadOnly
+  , databasePath
   , databaseVersion
   , Database
   -- ** Database modes

--- a/src/Notmuch/Binding.chs
+++ b/src/Notmuch/Binding.chs
@@ -241,6 +241,10 @@ database_get_path :: Database a -> IO FilePath
 database_get_path db =
   withDatabase db {#call unsafe database_get_path #} >>= peekCString
 
+-- | Get the path of the database
+databasePath :: Database a -> FilePath
+databasePath = System.IO.Unsafe.unsafePerformIO . database_get_path
+
 database_get_version :: Database a -> IO Int
 database_get_version db =
   fromIntegral <$> withDatabase db {#call unsafe database_get_version #}

--- a/tools/IndexFile.hs
+++ b/tools/IndexFile.hs
@@ -1,0 +1,45 @@
+-- This file is part of hs-notmuch - Haskell Notmuch binding
+-- Copyright (C) 2019  Fraser Tweedale
+--
+-- hs-notmuch is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-
+
+Index or remove the given file.
+
+-}
+
+{-# LANGUAGE LambdaCase #-}
+
+import Control.Monad.Except ((>=>), runExceptT)
+import System.Environment (getArgs)
+import System.Exit (die)
+
+import Notmuch
+
+main :: IO ()
+main = getArgs >>= \case
+  [dbDir, '-':path] -> remove dbDir path
+  [dbDir, path] -> index dbDir path
+  _ -> die "usage: hs-notmuch-index-file DB-DIR [-]PATH"
+
+index :: FilePath -> FilePath -> IO ()
+index dbDir path =
+  runExceptT (databaseOpen dbDir >>= flip indexFile path)
+  >>= either (die . (show :: Status -> String)) (messageId >=> print)
+
+remove :: FilePath -> FilePath -> IO ()
+remove dbDir path =
+  runExceptT (databaseOpen dbDir >>= flip removeFile path)
+  >>= either (die . (show :: Status -> String)) print

--- a/tools/TagSet.hs
+++ b/tools/TagSet.hs
@@ -16,7 +16,7 @@
 
 {-
 
-Search a notmuch database and print the filenames of each email found.
+Add or remove a tag from all messages matching query.
 
 -}
 


### PR DESCRIPTION
Also a few minor drive-by fixes.

```
Changes:

70f1887 (Fraser Tweedale, 29 minutes ago)
   add hs-notmuch-index-file program

   Add the hs-notmuch-index-file program to demonstrate and test indexFile and
   removeFile.

   Related: https://github.com/purebred-mua/hs-notmuch/issues/34

df0a8b3 (Fraser Tweedale, 30 minutes ago)
   add removeFile

   Fixes: https://github.com/purebred-mua/hs-notmuch/issues/34

5279fbc (Fraser Tweedale, 2 hours ago)
   add indexFile

   Part of: https://github.com/purebred-mua/hs-notmuch/issues/34

7fa3c03 (Fraser Tweedale, 2 hours ago)
   withFrozenMessage: exclude thaw in computation

   Use RankNTypes to require the computation argument to work for any degree
   of frozenness:

     withFrozenMessage
      :: (forall n. Message n RW -> IO a)
      -> Message 0 RW
      -> IO a

   The thaw function:

     message_thaw
      :: (1 <= n)
      => Message n RW -> IO (Message (n - 1) RW)

   is thereby excluded from the inner computation.

d13f349 (Fraser Tweedale, 2 hours ago)
   .gitignore: add cabal v2 artifacts

32edfdc (Fraser Tweedale, 8 hours ago)
   hs-notmuch-tag-set: fix description

53d09af (Fraser Tweedale, 19 hours ago)
   support non-error nonzero status scenarios

   For some libnotmuch routines, a nonzero status doesn't necessarily mean
   error.  For example, notmuch_database_index_file returns 
   NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID when message ID was already in the
   database, and it is considered a success case.

   Add variants of 'status' and 'constructF' that take a predicate to 
   discriminate success and failure statuses, for use in such scenarios.

   Part of: https://github.com/purebred-mua/hs-notmuch/issues/34
```